### PR TITLE
Fixed Issues with references

### DIFF
--- a/ConfigMgr Remote Compliance.ps1
+++ b/ConfigMgr Remote Compliance.ps1
@@ -5,8 +5,9 @@
 
 # Set the source directory
 $scriptRoot = [System.AppDomain]::CurrentDomain.BaseDirectory.TrimEnd('\')
-if ($scriptRoot -eq $PSHOME.TrimEnd('\')){
-    $scriptRoot = $PSScriptRoot}
+if ($scriptRoot -eq $PSHOME.TrimEnd('\')) {
+    $scriptRoot = $PSScriptRoot
+}
 $Source = $scriptRoot
 
 # Load in function library
@@ -29,15 +30,17 @@ $PSFiles = @(
 )
 
 $Hashes = @{
-    "About.ps1" = '30D81D06FD7B561AF92A260CD15A63A3CA7E8981AB75A5B3F7C54DCEC4040CFB'
-    "ClassLibrary.ps1" = 'E526558B23F95F341F07D5E8F578F46CC1BC485FD1E68C281801AD3640617060'
-    "EventLibrary.ps1" = '1A9DE4CA9F0A75A3289E47E5C271BB104EE1E2FD627B2B4472A682310A8EB69C'
-    "FunctionLibrary.ps1" = '3F45C4C6204C14183D10F7E8D03508FFBA883E4F7632FB4CF7367A62E0B32F42'
-    "About.xaml" = '4366B0E00578D2F8CE08C15E488D24561D0A7E95C0186D3137636488F11E1930'
-    "App.xaml" = '3694F7887B31AD6E47A801F47B93E8AEAC522CCEDBB89FB09C690F41E93919B5'
-    "Help.xaml" = 'D61F971EA8D454F9961966CEDB1FB108D625A486664AA08A6D5BB09FB4AA8469'
+    "About.ps1"             = '30D81D06FD7B561AF92A260CD15A63A3CA7E8981AB75A5B3F7C54DCEC4040CFB'
+    "ClassLibrary.ps1"      = 'E526558B23F95F341F07D5E8F578F46CC1BC485FD1E68C281801AD3640617060'
+    "EventLibrary.ps1"      = '1A9DE4CA9F0A75A3289E47E5C271BB104EE1E2FD627B2B4472A682310A8EB69C'
+    "FunctionLibrary.ps1"   = '3F45C4C6204C14183D10F7E8D03508FFBA883E4F7632FB4CF7367A62E0B32F42'
+    "About.xaml"            = '4366B0E00578D2F8CE08C15E488D24561D0A7E95C0186D3137636488F11E1930'
+    "App.xaml"              = '3694F7887B31AD6E47A801F47B93E8AEAC522CCEDBB89FB09C690F41E93919B5'
+    "Help.xaml"             = 'D61F971EA8D454F9961966CEDB1FB108D625A486664AA08A6D5BB09FB4AA8469'
     "HelpFlowDocument.xaml" = '928C28274AC68C311F703082FCBFA6DB20CBD5279224EC2DD415DEC33A87862D'
 }
+
+# Check File Hashes
 <#
 $XAMLFiles | foreach {
 
@@ -59,10 +62,9 @@ $PSFiles | foreach {
 #>
 
 # Do PS version check
-If ($PSVersionTable.PSVersion.Major -lt 5)
-{
-  New-PopupMessage -Message "ConfigMgr Remote Compliance cannot start because it requires PowerShell 5 or greater. Please upgrade your PowerShell version." -Title "ConfigMgr Remote Compliance" -ButtonType Ok -IconType Stop
-  Break
+If ($PSVersionTable.PSVersion.Major -lt 5) {
+    New-PopupMessage -Message "ConfigMgr Remote Compliance cannot start because it requires PowerShell 5 or greater. Please upgrade your PowerShell version." -Title "ConfigMgr Remote Compliance" -ButtonType Ok -IconType Stop
+    Break
 }
 
 
@@ -80,11 +82,11 @@ Add-Type -Path "$Source\bin\MaterialDesignThemes.Wpf.dll"
 
 
 # Create a synchronized hash table and add the WPF window and its named elements to it
-$UI = [System.Collections.Hashtable]::Synchronized(@{})
+$UI = [System.Collections.Hashtable]::Synchronized(@{ })
 $UI.Window = [Windows.Markup.XamlReader]::Load((New-Object -TypeName System.Xml.XmlNodeReader -ArgumentList $xaml))
 $xaml.SelectNodes("//*[@*[contains(translate(name(.),'n','N'),'Name')]]") | ForEach-Object -Process {
     $UI.$($_.Name) = $UI.Window.FindName($_.Name)
-    }
+}
 
 # Add an observable collection as a datasource and set datacontext etc
 $UI.DataContext = New-Object System.Collections.ObjectModel.ObservableCollection[Object]
@@ -100,32 +102,26 @@ $UI.Window.Icon = "$Source\bin\audit.ico"
 
 #endregion
 
-
-
 # Load additional "libraries" and scripts
 
 . "$Source\bin\ClassLibrary.ps1"
 . "$Source\bin\EventLibrary.ps1"
 . "$Source\bin\About.ps1"
 
-
-
 # Region to display the UI
 #region DisplayUI
 
 # If code is running in ISE, use ShowDialog()...
-if ($psISE)
-{
-    $null = $UI.window.Dispatcher.InvokeAsync{$UI.window.ShowDialog()}.Wait()
+if ($psISE) {
+    $null = $UI.window.Dispatcher.InvokeAsync{ $UI.window.ShowDialog() }.Wait()
 }
 # ...otherwise run as an application
-Else
-{
+Else {
     # Make PowerShell Disappear
     $windowcode = '[DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);'
     $asyncwindow = Add-Type -MemberDefinition $windowcode -Name Win32ShowWindowAsync -Namespace Win32Functions -PassThru
     $null = $asyncwindow::ShowWindowAsync((Get-Process -PID $pid).MainWindowHandle, 0)
- 
+
     $app = New-Object -TypeName Windows.Application
     $app.Run($UI.Window)
 }

--- a/ConfigMgr Remote Compliance.ps1
+++ b/ConfigMgr Remote Compliance.ps1
@@ -4,18 +4,10 @@
 
 
 # Set the source directory
-$OS = (Get-CimInstance -ClassName Win32_OperatingSystem -Property OSArchitecture).OSArchitecture
-If ($OS -eq "32-bit")
-{
-    $ProgramFiles = $env:ProgramFiles
-}
-If ($OS -eq "64-bit")
-{
-    $ProgramFiles = ${env:ProgramFiles(x86)}
-}
-
-$Source = "$ProgramFiles\SMSAgent\ConfigMgr Remote Compliance"
-
+$scriptRoot = [System.AppDomain]::CurrentDomain.BaseDirectory.TrimEnd('\')
+if ($scriptRoot -eq $PSHOME.TrimEnd('\')){
+    $scriptRoot = $PSScriptRoot}
+$Source = $scriptRoot
 
 # Load in function library
 . "$Source\bin\FunctionLibrary.ps1"

--- a/bin/About.ps1
+++ b/bin/About.ps1
@@ -6,11 +6,11 @@
 [XML]$Xaml = [System.IO.File]::ReadAllLines("$Source\XAML Files\About.xaml") 
 
 # Create a synchronized hash table and add the WPF window and its named elements to it
-$AboutUI = [System.Collections.Hashtable]::Synchronized(@{})
+$AboutUI = [System.Collections.Hashtable]::Synchronized(@{ })
 $AboutUI.Window = [Windows.Markup.XamlReader]::Load((New-Object -TypeName System.Xml.XmlNodeReader -ArgumentList $xaml))
 $xaml.SelectNodes("//*[@*[contains(translate(name(.),'n','N'),'Name')]]") | ForEach-Object -Process {
     $AboutUI.$($_.Name) = $AboutUI.Window.FindName($_.Name)
-    }
+}
 
 # Add an observable collection as a datasource
 $AboutUI.Window.DataContext = $UI.VersionHistory
@@ -19,16 +19,16 @@ $AboutUI.Window.DataContext = $UI.VersionHistory
 $AboutUI.Window.Icon = "$Source\bin\audit.ico"
 
 # Event: Cancel closure and hide
-$AboutUI.Window.Add_Closing({
-    $_.Cancel = $True
-    $This.Hide()
-})
+$AboutUI.Window.Add_Closing( {
+        $_.Cancel = $True
+        $This.Hide()
+    })
 
 # Event: hyperlink clicks
-$AboutUI.BlogLink,$AboutUI.MDLink, $AboutUI.GitLink, $AboutUI.PayPalLink | foreach {
+$AboutUI.BlogLink, $AboutUI.MDLink, $AboutUI.GitLink, $AboutUI.PayPalLink | ForEach-Object {
 
-    $_.Add_Click({
-        Start-Process $This.NavigateUri
-    })
+    $_.Add_Click( {
+            Start-Process $This.NavigateUri
+        })
 
 }

--- a/bin/ClassLibrary.ps1
+++ b/bin/ClassLibrary.ps1
@@ -1,38 +1,32 @@
 ﻿# Custom class to create a background powershell job
-class BackgroundJob
-{
+class BackgroundJob {
     # Properties
-    hidden $PowerShell = [powershell]::Create() 
+    hidden $PowerShell = [powershell]::Create()
     hidden $Handle = $null
     hidden $Runspace = $null
     $Result = $null
     $RunspaceID = $This.PowerShell.Runspace.ID
     $PSInstance = $This.PowerShell
 
-    
+
     # Constructor (just code block)
-    BackgroundJob ([scriptblock]$Code)
-    { 
+    BackgroundJob ([scriptblock]$Code) {
         $This.PowerShell.AddScript($Code)
     }
 
     # Constructor (code block + arguments)
-    BackgroundJob ([scriptblock]$Code,$Arguments)
-    { 
+    BackgroundJob ([scriptblock]$Code, $Arguments) {
         $This.PowerShell.AddScript($Code)
-        foreach ($Argument in $Arguments)
-        {
+        foreach ($Argument in $Arguments) {
             $This.PowerShell.AddArgument($Argument)
         }
     }
 
     # Constructor (code block + arguments + functions)
-    BackgroundJob ([scriptblock]$Code,$Arguments,$Functions)
-    { 
+    BackgroundJob ([scriptblock]$Code, $Arguments, $Functions) {
         $InitialSessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
         $Scope = [System.Management.Automation.ScopedItemOptions]::AllScope
-        foreach ($Function in $Functions)
-        {
+        foreach ($Function in $Functions) {
             $FunctionName = $Function.Split('\')[1]
             $FunctionDefinition = Get-Content $Function -ErrorAction Stop
             $SessionStateFunction = New-Object -TypeName System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList $FunctionName, $FunctionDefinition, $Scope, $null
@@ -42,44 +36,37 @@ class BackgroundJob
         $This.PowerShell.Runspace = $This.Runspace
         $This.Runspace.Open()
         $This.PowerShell.AddScript($Code)
-        foreach ($Argument in $Arguments)
-        {
+        foreach ($Argument in $Arguments) {
             $This.PowerShell.AddArgument($Argument)
         }
     }
-    
+
     # Start Method
-    Start()
-    {
+    Start() {
         $THis.Handle = $This.PowerShell.BeginInvoke()
     }
 
     # Stop Method
-    Stop()
-    {
+    Stop() {
         $This.PowerShell.Stop()
     }
 
     # Receive Method
-    [object]Receive()
-    {
+    [object]Receive() {
         $This.Result = $This.PowerShell.EndInvoke($This.Handle)
         return $This.Result
     }
 
     # Remove Method
-    Remove()
-    {
+    Remove() {
         $This.PowerShell.Dispose()
-        If ($This.Runspace)
-        {
+        If ($This.Runspace) {
             $This.Runspace.Dispose()
         }
     }
 
     # Get Status Method
-    [object]GetStatus()
-    {
+    [object]GetStatus() {
         return $This.PowerShell.InvocationStateInfo
     }
 }

--- a/bin/EventLibrary.ps1
+++ b/bin/EventLibrary.ps1
@@ -1,34 +1,31 @@
 ﻿
 # Event: On closure of the window
-$UI.Window.Add_Closing({
-    
-    # Remove any existing jobs
-    If ($UI.Job)
-    {
-        $UI.Job.Stop()
-        $UI.Job.Remove()
-    }
-    If ($UI.EvalJob)
-    {
-        $UI.EvalJob.Stop()
-        $UI.EvalJob.Remove()
-    }
-    If ($UI.VersionCheckJob)
-    {
-        $UI.VersionCheckJob.Stop()
-        $UI.VersionCheckJob.Remove()
-    }
+$UI.Window.Add_Closing( {
 
-    # Cleanup Reports
-    $UI.Reports | foreach {
-        Remove-Item $_
-    }
+        # Remove any existing jobs
+        If ($UI.Job) {
+            $UI.Job.Stop()
+            $UI.Job.Remove()
+        }
+        If ($UI.EvalJob) {
+            $UI.EvalJob.Stop()
+            $UI.EvalJob.Remove()
+        }
+        If ($UI.VersionCheckJob) {
+            $UI.VersionCheckJob.Stop()
+            $UI.VersionCheckJob.Remove()
+        }
 
-})
+        # Cleanup Reports
+        $UI.Reports | ForEach-Object {
+            Remove-Item $_
+        }
+
+    })
 
 # Event: When expander expanded
 $UI.expander.Add_Expanded{
-    
+
     # Increase the height
     $UI.expander.Height = 150
 
@@ -36,7 +33,7 @@ $UI.expander.Add_Expanded{
 
 # Event: When expander collapsed
 $UI.expander.Add_Collapsed{
-    
+
     # Return to previous height
     $UI.expander.Height = 50
 
@@ -48,18 +45,15 @@ $Code = {
     $ComputerName = $UI.ComputerName.Text
 
     # Clear the OCs before repopulating
-    If ($UI.DataContext[0])
-    {
+    If ($UI.DataContext[0]) {
         $UI.DataContext.Clear()      
     }
 
-    If ($UI.Baselines[0])
-    {
+    If ($UI.Baselines[0]) {
         $UI.Baselines.Clear()      
     }
 
-    If ($UI.User[0])
-    {
+    If ($UI.User[0]) {
         $UI.User.Clear()      
     }
 
@@ -69,24 +63,22 @@ $Code = {
 
     # Define the code to run in the background job
     $Code = {
-        Param($UI,$ComputerName)
+        Param($UI, $ComputerName)
         Get-Configurations -UI $UI -ComputerName $ComputerName
     }
 
     # Remove any existing jobs
-    If ($UI.Job)
-    {
+    If ($UI.Job) {
         $UI.Job.Stop()
         $UI.Job.Remove()
     }
-    If ($UI.EvalJob)
-    {
+    If ($UI.EvalJob) {
         $UI.EvalJob.Stop()
         $UI.EvalJob.Remove()
     }
 
     # Create and start a background job
-    $UI.Job = [BackgroundJob]::new($Code,@($UI,$ComputerName),@("Function:\Get-Configurations","Function:\Write-UILog"))
+    $UI.Job = [BackgroundJob]::new($Code, @($UI, $ComputerName), @("Function:\Get-Configurations", "Function:\Write-UILog"))
     $UI.Job.Start()
 
 }
@@ -99,154 +91,140 @@ $UI.BT_Config.Add_Click{
 }
 
 # Event: When hit enter in ComputerName textbox
-$UI.ComputerName.Add_KeyDown({
+$UI.ComputerName.Add_KeyDown( {
     
-    if ($_.Key -eq 'Return')
-    {
-        Invoke-Command -ScriptBlock $Code
-    }
+        if ($_.Key -eq 'Return') {
+            Invoke-Command -ScriptBlock $Code
+        }
 
-})
+    })
 
 # Event: When a row is selected in the datagrid
-$UI.dataGrid.Add_SelectionChanged({
+$UI.dataGrid.Add_SelectionChanged( {
     
-    # Enable the report button
-    $UI.BT_Report.IsEnabled = $true
+        # Enable the report button
+        $UI.BT_Report.IsEnabled = $true
 
-    # Enable (machine-context) or disable (user-context) the eval button
-    If ($This.SelectedItem.'Is Machine Target?' -eq $true)
-    {
-        $UI.BT_Eval.IsEnabled = $true
-    }
-    Else
-    {
-        $UI.BT_Eval.IsEnabled = $false
-    }
+        # Enable (machine-context) or disable (user-context) the eval button
+        If ($This.SelectedItem.'Is Machine Target?' -eq $true) {
+            $UI.BT_Eval.IsEnabled = $true
+        }
+        Else {
+            $UI.BT_Eval.IsEnabled = $false
+        }
 
-})
+    })
 
 # Event: When refresh button is clicked
-$UI.BT_Refresh.Add_Click({
+$UI.BT_Refresh.Add_Click( {
 
-    Invoke-Command -ScriptBlock $Code
+        Invoke-Command -ScriptBlock $Code
 
-})
+    })
 
 # Event: When report button is clicked
-$UI.BT_Report.Add_Click({
+$UI.BT_Report.Add_Click( {
 
-    # Get the compliance details XML string
-    # For machine-targeted configuration
-    If (($UI.Baselines[0] | where {$_.Name -eq $UI.dataGrid.SelectedItem.Name}).IsMachineTarget -eq "True")
-    {
-        Write-UILog -Severity Information -Message "Generating report for '$($UI.dataGrid.SelectedItem.Name)' baseline" -UI $UI
-        $ComplianceDetails = ($UI.Baselines[0] | where {$_.Name -eq $UI.dataGrid.SelectedItem.Name}).ComplianceDetails
-    }
-    # For user-targeted configuration
-    Else
-    {
-        # If logged-on user was detected
-        If ($UI.User)
-        {
-            Write-UILog -Severity Information -Message "Generating report for '$($UI.dataGrid.SelectedItem.Name)' baseline in context of user '$($UI.User[1])'" -UI $UI
-            $ComputerName = $UI.ComputerName.Text
-            $ScopeName = ($UI.Baselines[0] | where {$_.Name -eq $UI.dataGrid.SelectedItem.Name}).ScopeName
-            $Version = ($UI.Baselines[0] | where {$_.Name -eq $UI.dataGrid.SelectedItem.Name}).Revision
-            Try
-            {
-                # Generate the compliance details in the logged-on user context
-                $Report = Invoke-CimMethod -ComputerName $ComputerName -Namespace ROOT\ccm\dcm -ClassName SMS_DesiredConfiguration -MethodName "GetUserReport" -Arguments @{ 
-                    Name = $ScopeName; 
-                    UserSID = $UI.User[0]; 
-                    Version = $Version } -ErrorAction Stop
-                $ComplianceDetails = $Report.ComplianceDetails
+        # Get the compliance details XML string
+        # For machine-targeted configuration
+        If (($UI.Baselines[0] | Where-Object { $_.Name -eq $UI.dataGrid.SelectedItem.Name }).IsMachineTarget -eq "True") {
+            Write-UILog -Severity Information -Message "Generating report for '$($UI.dataGrid.SelectedItem.Name)' baseline" -UI $UI
+            $ComplianceDetails = ($UI.Baselines[0] | Where-Object { $_.Name -eq $UI.dataGrid.SelectedItem.Name }).ComplianceDetails
+        }
+        # For user-targeted configuration
+        Else {
+            # If logged-on user was detected
+            If ($UI.User) {
+                Write-UILog -Severity Information -Message "Generating report for '$($UI.dataGrid.SelectedItem.Name)' baseline in context of user '$($UI.User[1])'" -UI $UI
+                $ComputerName = $UI.ComputerName.Text
+                $ScopeName = ($UI.Baselines[0] | Where-Object { $_.Name -eq $UI.dataGrid.SelectedItem.Name }).ScopeName
+                $Version = ($UI.Baselines[0] | Where-Object { $_.Name -eq $UI.dataGrid.SelectedItem.Name }).Revision
+                Try {
+                    # Generate the compliance details in the logged-on user context
+                    $Report = Invoke-CimMethod -ComputerName $ComputerName -Namespace ROOT\ccm\dcm -ClassName SMS_DesiredConfiguration -MethodName "GetUserReport" -Arguments @{ 
+                        Name    = $ScopeName;
+                        UserSID = $UI.User[0];
+                        Version = $Version
+                    } -ErrorAction Stop
+                    $ComplianceDetails = $Report.ComplianceDetails
+                }
+                Catch {
+                    Write-UILog -Severity Error -Message "Could not generate user report for baseline '$($UI.dataGrid.SelectedItem.Name)' and user $($UI.User[1])'" -UI $UI
+                    $UI.expander.IsExpanded = $True
+                    Return
+                }
             }
-            Catch
-            {
-                Write-UILog -Severity Error -Message "Could not generate user report for baseline '$($UI.dataGrid.SelectedItem.Name)' and user $($UI.User[1])'" -UI $UI
+            Else {
+                Write-UILog -Severity Error -Message "Could not generate user report for baseline '$($UI.dataGrid.SelectedItem.Name)' as no user context was detected.'" -UI $UI
                 $UI.expander.IsExpanded = $True
                 Return
             }
-        }
-        Else
-        {
-            Write-UILog -Severity Error -Message "Could not generate user report for baseline '$($UI.dataGrid.SelectedItem.Name)' as no user context was detected.'" -UI $UI
-            $UI.expander.IsExpanded = $True
-            Return
+
+            # Error is return value is not 0
+            If ($Report.ReturnValue -ne 0) {
+                Write-UILog -Severity Error -Message "Could not generate report: ReturnValue $($Report.ReturnValue)" -UI $UI
+                $UI.expander.IsExpanded = $true
+                Return
+            }
         }
 
-        # Error is return value is not 0
-        If ($Report.ReturnValue -ne 0)
-        {
-            Write-UILog -Severity Error -Message "Could not generate report: ReturnValue $($Report.ReturnValue)" -UI $UI
+        # Generate the compliance report
+        Try {
+            Generate-Report -ComplianceDetails $ComplianceDetails
+        }
+        Catch {
+            Write-UILog -Severity Error -Message "Problem generating report: $_" -UI $UI
             $UI.expander.IsExpanded = $true
-            Return
         }
-    }
 
-    # Generate the compliance report
-    Try
-    {
-        Generate-Report -ComplianceDetails $ComplianceDetails
-    }
-    Catch
-    {
-        Write-UILog -Severity Error -Message "Problem generating report: $_" -UI $UI
-        $UI.expander.IsExpanded = $true
-    }
-
-})
+    })
 
 # Event: When eval button is clicked
-$UI.BT_Eval.Add_Click({
-    
-    $ComputerName = $UI.ComputerName.Text
-    $DisplayName = $UI.dataGrid.SelectedItem.Name
+$UI.BT_Eval.Add_Click( {
 
-    # Disable the report, refresh and eval buttons
-    $UI.BT_Report, $UI.BT_Refresh, $this | foreach {
-        $_.IsEnabled = $False
-    }
+        $ComputerName = $UI.ComputerName.Text
+        $DisplayName = $UI.dataGrid.SelectedItem.Name
 
-    # Write to logging window
-    Write-UILog -Severity Information -Message "Triggering evaluation of '$($UI.dataGrid.SelectedItem.Name)' baseline" -UI $UI
+        # Disable the report, refresh and eval buttons
+        $UI.BT_Report, $UI.BT_Refresh, $this | ForEach-Object {
+            $_.IsEnabled = $False
+        }
 
-    # Remove any existing eval job
-    If ($UI.EvalJob)
-    {
-        $UI.EvalJob.Stop()
-        $UI.EvalJob.Remove()
-    }
+        # Write to logging window
+        Write-UILog -Severity Information -Message "Triggering evaluation of '$($UI.dataGrid.SelectedItem.Name)' baseline" -UI $UI
 
-    # Define code to run in background job
-    $Code = {
+        # Remove any existing eval job
+        If ($UI.EvalJob) {
+            $UI.EvalJob.Stop()
+            $UI.EvalJob.Remove()
+        }
 
-        Param ($UI,$DisplayName,$ComputerName)
-        Evaluate-Baseline -UI $UI -DisplayName $DisplayName -ComputerName $ComputerName
+        # Define code to run in background job
+        $Code = {
+
+            Param ($UI, $DisplayName, $ComputerName)
+            Evaluate-Baseline -UI $UI -DisplayName $DisplayName -ComputerName $ComputerName
          
-    }
+        }
 
-    # Create and start a background job
-    $UI.EvalJob = [BackgroundJob]::new($Code,@($UI,$DisplayName,$ComputerName),@("Function:\Get-Configurations","Function:\Write-UILog","Function:\Evaluate-Baseline"))
-    $UI.EvalJob.Start()
+        # Create and start a background job
+        $UI.EvalJob = [BackgroundJob]::new($Code, @($UI, $DisplayName, $ComputerName), @("Function:\Get-Configurations", "Function:\Write-UILog", "Function:\Evaluate-Baseline"))
+        $UI.EvalJob.Start()
 
-})
+    })
 
 # Event: Text changed in computername text box
-$UI.ComputerName.Add_TextChanged({
-    If ($This.Text -ne "")
-    {
-        $UI.BT_Config.IsEnabled = $true
-        $UI.ViewLogs.IsEnabled = $true
-    }
-    Else
-    {
-        $UI.BT_Config.IsEnabled = $false
-        $UI.ViewLogs.IsEnabled = $false
-    }
+$UI.ComputerName.Add_TextChanged( {
+        If ($This.Text -ne "") {
+            $UI.BT_Config.IsEnabled = $true
+            $UI.ViewLogs.IsEnabled = $true
+        }
+        Else {
+            $UI.BT_Config.IsEnabled = $false
+            $UI.ViewLogs.IsEnabled = $false
+        }
 
-})
+    })
 
 # Useful logs files for DCM
 $Logs = @(
@@ -259,138 +237,131 @@ $Logs = @(
 )
 
 # Event: Open log file from menu items
-$Logs | foreach {
+$Logs | ForEach-Object {
     $Log = $_
 
-    Switch($Log)
-    {
-        DCMAgent {$UI.$Log.Add_Click({
-            Try
-            {
-                Write-UILog -Severity Information -Message "Opening DCMAgent.log on $($UI.ComputerName.Text)" -UI $UI
-                Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\DCMAgent.log" -ErrorAction Stop
-            }
-            Catch
-            {
-                Write-UILog -Severity Error -Message "Could not open DCMAgent.log on $($UI.ComputerName.Text): $_" -UI $UI
-                $UI.expander.IsExpanded = $true
-            }
-        })
+    Switch ($Log) {
+        DCMAgent {
+            $UI.$Log.Add_Click( {
+                    Try {
+                        Write-UILog -Severity Information -Message "Opening DCMAgent.log on $($UI.ComputerName.Text)" -UI $UI
+                        Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\DCMAgent.log" -ErrorAction Stop
+                    }
+                    Catch {
+                        Write-UILog -Severity Error -Message "Could not open DCMAgent.log on $($UI.ComputerName.Text): $_" -UI $UI
+                        $UI.expander.IsExpanded = $true
+                    }
+                })
         }
-        DCMReporting {$UI.$Log.Add_Click({
-            Try
-            {
-                Write-UILog -Severity Information -Message "Opening DCMReporting.log on $($UI.ComputerName.Text)" -UI $UI
-                Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\DCMReporting.log" -ErrorAction Stop
-            }
-            Catch
-            {
-                Write-UILog -Severity Error -Message "Could not open DCMReporting.log on $($UI.ComputerName.Text): $_" -UI $UI
-                $UI.expander.IsExpanded = $true
-            }
-        })
+        DCMReporting {
+            $UI.$Log.Add_Click( {
+                    Try {
+                        Write-UILog -Severity Information -Message "Opening DCMReporting.log on $($UI.ComputerName.Text)" -UI $UI
+                        Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\DCMReporting.log" -ErrorAction Stop
+                    }
+                    Catch {
+                        Write-UILog -Severity Error -Message "Could not open DCMReporting.log on $($UI.ComputerName.Text): $_" -UI $UI
+                        $UI.expander.IsExpanded = $true
+                    }
+                })
         }
-        DCMWMIProvider {$UI.$Log.Add_Click({
-            Try
-            {
-                Write-UILog -Severity Information -Message "Opening DCMWMIProvider.log on $($UI.ComputerName.Text)" -UI $UI
-                Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\DCMWMIProvider.log" -ErrorAction Stop
-            }
-            Catch
-            {
-                Write-UILog -Severity Error -Message "Could not open DCMWMIProvider.log on $($UI.ComputerName.Text): $_" -UI $UI
-                $UI.expander.IsExpanded = $true
-            }
-        })
+        DCMWMIProvider {
+            $UI.$Log.Add_Click( {
+                    Try {
+                        Write-UILog -Severity Information -Message "Opening DCMWMIProvider.log on $($UI.ComputerName.Text)" -UI $UI
+                        Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\DCMWMIProvider.log" -ErrorAction Stop
+                    }
+                    Catch {
+                        Write-UILog -Severity Error -Message "Could not open DCMWMIProvider.log on $($UI.ComputerName.Text): $_" -UI $UI
+                        $UI.expander.IsExpanded = $true
+                    }
+                })
         }
-        StateMessage {$UI.$Log.Add_Click({
-            Try
-            {
-                Write-UILog -Severity Information -Message "Opening StateMessage.log on $($UI.ComputerName.Text)" -UI $UI
-                Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\StateMessage.log" -ErrorAction Stop
-            }
-            Catch
-            {
-                Write-UILog -Severity Error -Message "Could not open StateMessage.log on $($UI.ComputerName.Text): $_" -UI $UI
-                $UI.expander.IsExpanded = $true
-            }
-        })
+        StateMessage {
+            $UI.$Log.Add_Click( {
+                    Try {
+                        Write-UILog -Severity Information -Message "Opening StateMessage.log on $($UI.ComputerName.Text)" -UI $UI
+                        Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\StateMessage.log" -ErrorAction Stop
+                    }
+                    Catch {
+                        Write-UILog -Severity Error -Message "Could not open StateMessage.log on $($UI.ComputerName.Text): $_" -UI $UI
+                        $UI.expander.IsExpanded = $true
+                    }
+                })
         }
-        CIAgent {$UI.$Log.Add_Click({
-            Try
-            {
-                Write-UILog -Severity Information -Message "Opening CIAgent.log on $($UI.ComputerName.Text)" -UI $UI
-                Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\CIAgent.log" -ErrorAction Stop
-            }
-            Catch
-            {
-                Write-UILog -Severity Error -Message "Could not open CIAgent.log on $($UI.ComputerName.Text): $_" -UI $UI
-                $UI.expander.IsExpanded = $true
-            }
-        })
+        CIAgent {
+            $UI.$Log.Add_Click( {
+                    Try {
+                        Write-UILog -Severity Information -Message "Opening CIAgent.log on $($UI.ComputerName.Text)" -UI $UI
+                        Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\CIAgent.log" -ErrorAction Stop
+                    }
+                    Catch {
+                        Write-UILog -Severity Error -Message "Could not open CIAgent.log on $($UI.ComputerName.Text): $_" -UI $UI
+                        $UI.expander.IsExpanded = $true
+                    }
+                })
         }
-        CIStateStore {$UI.$Log.Add_Click({
-            Try
-            {
-                Write-UILog -Severity Information -Message "Opening CIStateStore.log on $($UI.ComputerName.Text)" -UI $UI
-                Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\CIStateStore.log" -ErrorAction Stop
-            }
-            Catch
-            {
-                Write-UILog -Severity Error -Message "Could not open CIStateStore.log on $($UI.ComputerName.Text): $_" -UI $UI
-                $UI.expander.IsExpanded = $true
-            }
-        })
+        CIStateStore {
+            $UI.$Log.Add_Click( {
+                    Try {
+                        Write-UILog -Severity Information -Message "Opening CIStateStore.log on $($UI.ComputerName.Text)" -UI $UI
+                        Invoke-Item -Path "\\$($UI.ComputerName.Text)\C$\Windows\CCM\Logs\CIStateStore.log" -ErrorAction Stop
+                    }
+                    Catch {
+                        Write-UILog -Severity Error -Message "Could not open CIStateStore.log on $($UI.ComputerName.Text): $_" -UI $UI
+                        $UI.expander.IsExpanded = $true
+                    }
+                })
         }
     }
 }
 
 # Event: About menu click
-$UI.About.Add_Click({
-    $null = $UI.window.Dispatcher.InvokeAsync{$AboutUI.Window.ShowDialog()}.Wait()
-})
+$UI.About.Add_Click( {
+        $null = $UI.window.Dispatcher.InvokeAsync{ $AboutUI.Window.ShowDialog() }.Wait()
+    })
 
 # Event: Window Loaded
-$UI.Window.Add_Loaded({
-    # Check if new version is available
-    [double]$ThisVersion = $UI.CurrentVersion
-    $Code = {
-        Param($UI,$ThisVersion)
-        Check-CurrentVersion -UI $UI -ThisVersion $ThisVersion
-    }
-    $UI.VersionCheckJob = [BackgroundJob]::new($Code,@($UI,$ThisVersion),"Function:\Check-CurrentVersion")
-    $UI.VersionCheckJob.Start()
+$UI.Window.Add_Loaded( {
+        # Check if new version is available
+        [double]$ThisVersion = $UI.CurrentVersion
+        $Code = {
+            Param($UI, $ThisVersion)
+            Check-CurrentVersion -UI $UI -ThisVersion $ThisVersion
+        }
+        $UI.VersionCheckJob = [BackgroundJob]::new($Code, @($UI, $ThisVersion), "Function:\Check-CurrentVersion")
+        $UI.VersionCheckJob.Start()
 
-})
+    })
 
 # Event: Update menu item clicked
-$UI.Update.Add_Click({
-    # Open link to download current version
-    Start-Process "https://gallery.technet.microsoft.com/ConfigMgr-Remote-Compliance-2a9e55f3"
-})
+$UI.Update.Add_Click( {
+        # Open link to download current version
+        Start-Process "https://gallery.technet.microsoft.com/ConfigMgr-Remote-Compliance-2a9e55f3"
+    })
 
 # Event: Help menu item clicked
-$UI.Help.Add_Click({
-    # Open help document
+$UI.Help.Add_Click( {
+        # Open help document
 
-    # Read the XAML code
-    [XML]$Xaml = [System.IO.File]::ReadAllLines("$Source\XAML Files\Help.xaml") 
+        # Read the XAML code
+        [XML]$Xaml = [System.IO.File]::ReadAllLines("$Source\XAML Files\Help.xaml") 
 
-    # Create a synchronized hash table and add the WPF window and its named elements to it
-    $HelpUI = [System.Collections.Hashtable]::Synchronized(@{})
-    $HelpUI.Window = [Windows.Markup.XamlReader]::Load((New-Object -TypeName System.Xml.XmlNodeReader -ArgumentList $xaml))
+        # Create a synchronized hash table and add the WPF window and its named elements to it
+        $HelpUI = [System.Collections.Hashtable]::Synchronized(@{ })
+        $HelpUI.Window = [Windows.Markup.XamlReader]::Load((New-Object -TypeName System.Xml.XmlNodeReader -ArgumentList $xaml))
     
-    # Set icon
-    $HelpUI.Window.Icon = "$Source\bin\audit.ico"
+        # Set icon
+        $HelpUI.Window.Icon = "$Source\bin\audit.ico"
 
-    # Read the FlowDocument content
-    [XML]$Xaml = [System.IO.File]::ReadAllLines("$Source\XAML Files\HelpFlowDocument.xaml")
-    $Reader = New-Object -TypeName System.Xml.XmlNodeReader -ArgumentList $xaml
-    $XamlDoc = [System.Windows.Markup.XamlReader]::Load($Reader)
+        # Read the FlowDocument content
+        [XML]$Xaml = [System.IO.File]::ReadAllLines("$Source\XAML Files\HelpFlowDocument.xaml")
+        $Reader = New-Object -TypeName System.Xml.XmlNodeReader -ArgumentList $xaml
+        $XamlDoc = [System.Windows.Markup.XamlReader]::Load($Reader)
 
-    # Add the FlowDocument to the Window
-    $HelpUI.Window.AddChild($XamlDoc)
+        # Add the FlowDocument to the Window
+        $HelpUI.Window.AddChild($XamlDoc)
 
-    # Show the window
-    $null = $HelpUI.window.Show()
-})
+        # Show the window
+        $null = $HelpUI.window.Show()
+    })

--- a/bin/FunctionLibrary.ps1
+++ b/bin/FunctionLibrary.ps1
@@ -1,72 +1,62 @@
 ﻿# Function to retrieve the configurations info from the remote computer
 function script:Get-Configurations {
-    Param($UI,$ComputerName)
+    Param($UI, $ComputerName)
 
     # Start progress ring
-    $UI.Window.Dispatcher.Invoke({
-        $UI.Progress.IsIndeterminate = $True
+    $UI.Window.Dispatcher.Invoke( {
+            $UI.Progress.IsIndeterminate = $True
         })
 
     # Write to logging window
     Write-UILog -Severity Information -Message "Retrieving configurations from $ComputerName" -UI $UI
 
     # Get CIM instances
-    Try
-    {
-        $Instances = Get-CimInstance -ComputerName $ComputerName -Namespace ROOT\ccm\dcm -ClassName SMS_DesiredConfiguration -OperationTimeoutSec 5 -ErrorAction Stop | Select DisplayName,Version,LastEvalTime,LastComplianceStatus,Status,ComplianceDetails,IsMachineTarget,Name
+    Try {
+        $Instances = Get-CimInstance -ComputerName $ComputerName -Namespace ROOT\ccm\dcm -ClassName SMS_DesiredConfiguration -OperationTimeoutSec 5 -ErrorAction Stop | Select-Object DisplayName, Version, LastEvalTime, LastComplianceStatus, Status, ComplianceDetails, IsMachineTarget, Name
     }
-    Catch
-    {
+    Catch {
         $Errored = $true
         # Open the expander to show the error
-        $UI.Window.Dispatcher.Invoke({
-            $UI.expander.IsExpanded = "True"
-            $UI.Progress.IsIndeterminate = $false
-        })
+        $UI.Window.Dispatcher.Invoke( {
+                $UI.expander.IsExpanded = "True"
+                $UI.Progress.IsIndeterminate = $false
+            })
         Write-UILog -Severity Error -Message "Could not retrieve configurations from $ComputerName`: $_" -UI $UI
         Return
     }
 
     # Find logged-on user SID
-    Try
-    {
+    Try {
         $CurrentUserSID = (Invoke-Command -ComputerName $ComputerName -ScriptBlock {
-            Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\SMS\CurrentUser -Name UserSID -ErrorAction Stop
-        }).UserSID
+                Get-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\SMS\CurrentUser -Name UserSID -ErrorAction Stop
+            }).UserSID
         $UI.User.Add($CurrentUserSID)
-        If ($CurrentUserSID)
-        {
+        If ($CurrentUserSID) {
             Write-UILog -Severity Information -Message "Found SID for logged-on user: $CurrentUserSID" -UI $UI
         }
-        Else
-        {
+        Else {
             Write-UILog -Severity Information -Message "No SID found for logged-on user. Perhaps no-one is currently logged on." -UI $UI
         }
     }
-    Catch
-    {
+    Catch {
         Write-UILog -Severity Warning -Message "Could not find SID for logged on user: $_" -UI $UI
     }
 
     # Translate user SID
-    If ($CurrentUserSID)
-    {
-        Try
-        {
+    If ($CurrentUserSID) {
+        Try {
             $SID = New-Object System.Security.Principal.SecurityIdentifier ($CurrentUserSID)
             $User = ($SID.Translate( [System.Security.Principal.NTAccount])).Value
             $UI.User.Add($User)
             Write-UILog -Severity Information -Message "Translated SID to $User" -UI $UI
         }
-        Catch
-        {
+        Catch {
             Write-UILog -Severity Warning -Message "Could not translate SID for logged-on user: $_" -UI $UI
         }
     }
 
     # If instances were found
-    If ($Instances)
-    {
+    If ($Instances) {
         # Create an arraylist to hold the baseline info from WMI
         $Baselines = New-Object System.Collections.ArrayList
 
@@ -81,33 +71,30 @@ function script:Get-Configurations {
         [void]$Table.Columns.Add('User Context')
 
         # Loop through the instances
-        $Instances | foreach {
+        $Instances | ForEach-Object {
             $Instance = $_
 
             # Process Machine-targeted configuration
-            If ($Instance.IsMachineTarget -eq $True)
-            {
-                $Baseline = '' | Select Name, Revision, 'Last Evaluation', 'Compliance State', 'Evaluation Status', ComplianceDetails, IsMachineTarget, 'User Context', 'ScopeName'
-                switch($Instance.LastComplianceStatus)
-                {
-                    0 {$Cstate = "NonCompliant"}
-                    1 {$Cstate = "Compliant"}
-                    2 {$Cstate = "NotApplicable"}
-                    3 {$Cstate = "Unknown"}
-                    4 {$Cstate = "Error"}
-                    5 {$Cstate = "NotEvaluated"}
+            If ($Instance.IsMachineTarget -eq $True) {
+                $Baseline = '' | Select-Object Name, Revision, 'Last Evaluation', 'Compliance State', 'Evaluation Status', ComplianceDetails, IsMachineTarget, 'User Context', 'ScopeName'
+                switch ($Instance.LastComplianceStatus) {
+                    0 { $Cstate = "NonCompliant" }
+                    1 { $Cstate = "Compliant" }
+                    2 { $Cstate = "NotApplicable" }
+                    3 { $Cstate = "Unknown" }
+                    4 { $Cstate = "Error" }
+                    5 { $Cstate = "NotEvaluated" }
                 }
-    
-                switch($Instance.Status)
-                {
-                    0 {$Estate = "Idle"}
-                    1 {$Estate = "Evaluation Started"}
-                    2 {$Estate = "Downloading Documents"}
-                    3 {$Estate = "In Progress"}
-                    4 {$Estate = "Failure"}
-                    5 {$Estate = "Reporting"}
+
+                switch ($Instance.Status) {
+                    0 { $Estate = "Idle" }
+                    1 { $Estate = "Evaluation Started" }
+                    2 { $Estate = "Downloading Documents" }
+                    3 { $Estate = "In Progress" }
+                    4 { $Estate = "Failure" }
+                    5 { $Estate = "Reporting" }
                 }
-    
+
                 # Create the baseline object
                 $Baseline.Name = $Instance.DisplayName
                 $Baseline.Revision = $Instance.Version
@@ -118,38 +105,33 @@ function script:Get-Configurations {
                 $Baseline.IsMachineTarget = $Instance.IsMachineTarget
                 $Baseline.'User Context' = "N/A"
                 $Baseline.ScopeName = $Instance.Name
-    
+
                 # Add the baseline object to the arraylist
                 [void]$Baselines.Add($Baseline)
-    
+
                 # Add a row to the datatable
-                $Table.Rows.Add($Baseline.Name,$Baseline.Revision, $Baseline.'Last Evaluation',$Baseline.'Compliance State', $Baseline.'Evaluation Status', $Baseline.IsMachineTarget, $Baseline.'User Context')
+                $Table.Rows.Add($Baseline.Name, $Baseline.Revision, $Baseline.'Last Evaluation', $Baseline.'Compliance State', $Baseline.'Evaluation Status', $Baseline.IsMachineTarget, $Baseline.'User Context')
             }
             # Process user-targeted configuration
-            Else
-            {
-                $Baseline = '' | Select Name, Revision, 'Last Evaluation', 'Compliance State', 'Evaluation Status', ComplianceDetails, IsMachineTarget, 'User Context', 'ScopeName'
-    
+            Else {
+                $Baseline = '' | Select-Object Name, Revision, 'Last Evaluation', 'Compliance State', 'Evaluation Status', ComplianceDetails, IsMachineTarget, 'User Context', 'ScopeName'
+
                 # Find compliance state of configuration in the logged-on user context
-                If ($CurrentUserSID)
-                {
-                    Try
-                    {
+                If ($CurrentUserSID) {
+                    Try {
                         $PolicyCompliance = (Invoke-CimMethod -ComputerName $ComputerName -Namespace ROOT\ccm\dcm -ClassName SMS_DesiredConfiguration -MethodName "GetComplianceForPolicyType" -Arguments @{ 
-                            UserSID = $CurrentUserSID; 
-                            PolicyType = $Instance.Name 
+                                UserSID    = $CurrentUserSID;
+                                PolicyType = $Instance.Name
                             }).ComplianceState
                     }
-                    Catch
-                    {
+                    Catch {
                         Write-UILog -Severity Error -Message "Could not determine compliance state for user-targeted configuration ($($Instance.DisplayName)): $_" -UI $UI
                     }
                 }
-                Else 
-                {
+                Else {
                     $PolicyCompliance = "Unknown"
                 }
-    
+
                 # Create the baseline object
                 $Baseline.Name = $Instance.DisplayName
                 $Baseline.Revision = $Instance.Version
@@ -158,43 +140,38 @@ function script:Get-Configurations {
                 $Baseline.'Evaluation Status' = "Unknown"
                 $Baseline.ComplianceDetails = $Instance.ComplianceDetails
                 $Baseline.IsMachineTarget = $Instance.IsMachineTarget
-                If ($User)
-                {
+                If ($User) {
                     $Baseline.'User Context' = $User
                 }
-                Else
-                {
+                Else {
                     $Baseline.'User Context' = "Unknown"
                 }
                 $Baseline.ScopeName = $Instance.Name
 
                 # Add the baseline object to the arraylist
                 [void]$Baselines.Add($Baseline)
-    
+
                 # Add a row to the datatable
-                $Table.Rows.Add($Baseline.Name,$Baseline.Revision, $Baseline.'Last Evaluation',$Baseline.'Compliance State', $Baseline.'Evaluation Status', $Baseline.IsMachineTarget, $Baseline.'User Context')
+                $Table.Rows.Add($Baseline.Name, $Baseline.Revision, $Baseline.'Last Evaluation', $Baseline.'Compliance State', $Baseline.'Evaluation Status', $Baseline.IsMachineTarget, $Baseline.'User Context')
             }
         }
     }
-    Else
-    {
-        If (!$Errored)
-        {
+    Else {
+        If (!$Errored) {
             Write-UILog -Severity Warning -Message "No configurations found." -UI $UI
         }
     }
 
     # Stop the progress ring and enable the refresh button
-    $UI.Window.Dispatcher.Invoke({
-       $UI.Progress.IsIndeterminate = $False
-       $UI.BT_Refresh.IsEnabled = $true
-    })
+    $UI.Window.Dispatcher.Invoke( {
+            $UI.Progress.IsIndeterminate = $False
+            $UI.BT_Refresh.IsEnabled = $true
+        })
 
     # If data was found, add to OCs
-    If ($Baselines)
-    {
-        $UI.Baselines.Add($Baselines) 
-        $UI.DataContext.Add($Table) 
+    If ($Baselines) {
+        $UI.Baselines.Add($Baselines)
+        $UI.DataContext.Add($Table)
     }
 }
 
@@ -202,41 +179,40 @@ function script:Get-Configurations {
 function script:Write-UILog {
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("Information","Warning","Error")]
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Information", "Warning", "Error")]
         $Severity,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [String]
         $Message,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         $UI
     )
 
     # Set some values based on severity
-    Switch($Severity)
-    {
-        "Information" {$Prefix = "[Information]"; $Colour = "Black"}
-        "Warning" {$Prefix = "[Warning]"; $Colour = "Orange"}
-        "Error" {$Prefix = "[Error]"; $Colour = "Red"}
+    Switch ($Severity) {
+        "Information" { $Prefix = "[Information]"; $Colour = "Black" }
+        "Warning" { $Prefix = "[Warning]"; $Colour = "Orange" }
+        "Error" { $Prefix = "[Error]"; $Colour = "Red" }
     }
 
     # Get the time
     $Time = "[$((Get-date).ToLongTimeString())]"
 
     # Call the dispatcher to update the UI
-    $UI.Window.Dispatcher.Invoke({
-        # Create the textblock
-        $TextBlock = New-Object System.Windows.Controls.TextBlock
-        $TextBlock.Text = "$Time $Prefix $Message"
-        $TextBlock.Foreground = $Colour
-        $TextBlock.TextWrapping = [System.Windows.TextWrapping]::Wrap
+    $UI.Window.Dispatcher.Invoke( {
+            # Create the textblock
+            $TextBlock = New-Object System.Windows.Controls.TextBlock
+            $TextBlock.Text = "$Time $Prefix $Message"
+            $TextBlock.Foreground = $Colour
+            $TextBlock.TextWrapping = [System.Windows.TextWrapping]::Wrap
 
-        # Add the textblock to the UI, move to the next line and scroll to end
-        $NewLine = New-Object System.Windows.Documents.LineBreak
-        $ui.FlowDocument.Blocks.FirstBlock.AddChild($TextBlock)
-        $ui.FlowDocument.Blocks.FirstBlock.AddChild($NewLine)
-        $UI.richTextBox.ScrollToEnd()
-    })
+            # Add the textblock to the UI, move to the next line and scroll to end
+            $NewLine = New-Object System.Windows.Documents.LineBreak
+            $ui.FlowDocument.Blocks.FirstBlock.AddChild($TextBlock)
+            $ui.FlowDocument.Blocks.FirstBlock.AddChild($NewLine)
+            $UI.richTextBox.ScrollToEnd()
+        })
 }
 
 # Function to generate the compliance report
@@ -248,58 +224,52 @@ function Generate-Report {
 
     # Set path to transform file, either local client or site server client
     $LocalClientPath = "$env:windir\CCM"
-    if ($env:SMS_LOG_PATH)
-    {
-        $SiteServerPath = ($env:SMS_LOG_PATH).Replace("\Microsoft Configuration Manager\logs","")
+    if ($env:SMS_LOG_PATH) {
+        $SiteServerPath = ($env:SMS_LOG_PATH).Replace("\Microsoft Configuration Manager\logs", "")
         $SiteServerPath = $SiteServerPath + "\SMS_CCM"
     }
-    If (Test-Path $LocalClientPath)
-    {
+    If (Test-Path $LocalClientPath) {
         $TransformFile = "$LocalClientPath\DCMReportTransform.xsl"
     }
-    ElseIf (Test-Path $SiteServerPath)
-    {
+    ElseIf (Test-Path $SiteServerPath) {
         $TransformFile = "$SiteServerPath\DCMReportTransform.xsl"
     }
-    Else
-    {
+    Else {
         Write-UILog -Severity Error -Message "Could not locate DCMReportTransform.xsl in the expected locations." -UI $UI
         Return
     }
 
     # Load transform file and update the dcm resource and style paths
     $SourceXSL = Get-Content $TransformFile -Raw
-    If ($SiteServerPath)
-    {
-        $SourceXSL = $SourceXSL.Replace("SMS_CCM","Program Files\SMS_CCM")      
+    If ($SiteServerPath) {
+        $SourceXSL = $SourceXSL.Replace("SMS_CCM", "Program Files\SMS_CCM")
     }
-    Else
-    {
-        $SourceXSL = $SourceXSL.Replace("SMS_CCM","Windows\CCM")
+    Else {
+        $SourceXSL = $SourceXSL.Replace("SMS_CCM", "Windows\CCM")
     }
-    
+
     # Create stylesheet as xmlreader
     $StyleSheet = [System.Xml.XmlReader]::Create([System.IO.StringReader]::new($SourceXSL))
     [void]$StyleSheet.Read()
-    
+
     # Load the compliance details xml string from the wmi data as xmlreader
     $XMLReader = [System.Xml.XmlReader]::Create([System.IO.StringReader]::new($ComplianceDetails))
     [void]$XMLReader.Read()
-    
+
     # Create the output object as xmlwriter
     $XMLWriter = [System.Xml.XmlWriter]::Create($Report)
-    
+
     # Thunderbirds are go...
     $XSLTransform = New-Object System.Xml.Xsl.XslCompiledTransform
     $XSLSettings = New-Object System.Xml.Xsl.XsltSettings
     $XSLSettings.EnableDocumentFunction = $true
     $XMLResolver = New-Object System.Xml.XmlUrlResolver
-    $XSLTransform.Load($StyleSheet,$XSLSettings,$XMLResolver)
-    $XSLTransform.Transform($XMLReader,$XMLWriter)
-    
+    $XSLTransform.Load($StyleSheet, $XSLSettings, $XMLResolver)
+    $XSLTransform.Transform($XMLReader, $XMLWriter)
+
     # Open the report
     Invoke-Item $Report
-    
+
     # Add to array for cleanup
     $UI.Reports += $Report
 
@@ -311,81 +281,75 @@ function Generate-Report {
 
 # Function to trigger a baseline evaluation
 Function script:Evaluate-Baseline {
-    Param($UI,$DisplayName,$ComputerName)
+    Param($UI, $DisplayName, $ComputerName)
 
     # Start the progress ring
-    $UI.Window.Dispatcher.Invoke({
-        $UI.Progress.IsIndeterminate = $true
-    })
+    $UI.Window.Dispatcher.Invoke( {
+            $UI.Progress.IsIndeterminate = $true
+        })
 
     # Get the instance from WMI
-    Try
-    {
-        $Baseline = Get-CimInstance -ComputerName $ComputerName -Namespace root\ccm\dcm -ClassName SMS_DesiredConfiguration -ErrorAction Stop | Where {$_.DisplayName -eq $DisplayName} | Select IsMachineTarget, Version, Name
+    Try {
+        $Baseline = Get-CimInstance -ComputerName $ComputerName -Namespace root\ccm\dcm -ClassName SMS_DesiredConfiguration -ErrorAction Stop | Where-Object { $_.DisplayName -eq $DisplayName } | Select-Object IsMachineTarget, Version, Name
     }
-    Catch
-    {
+    Catch {
         Write-UILog -Severity Error -Message "Problem getting CIM Instance: $_" -UI $UI
-        $UI.Window.Dispatcher.Invoke({
-            $UI.Progress.IsIndeterminate = $false
-            $UI.expander.IsExpanded = $true
-        })
+        $UI.Window.Dispatcher.Invoke( {
+                $UI.Progress.IsIndeterminate = $false
+                $UI.expander.IsExpanded = $true
+            })
         Return
     }
 
     # Define the arguments in hash for the Invoke-CimMethod cmdlet
     $Arguments = @{
-        Name = $baseline.Name
-        Version = $baseline.Version
+        Name            = $baseline.Name
+        Version         = $baseline.Version
         IsMachineTarget = [bool]$Baseline.IsMachineTarget
-        IsEnforced = $True
-    
+        IsEnforced      = $True
+
     }
-    
+
     # Invoke the method. Operation timeout will wait for 10 minutes. Consider the ScriptExecutionTimeout value in WMI.
-    Try
-    {
+    Try {
         $UI.Result = Invoke-CimMethod -ComputerName $ComputerName -Namespace ROOT\ccm\dcm -ClassName SMS_DesiredConfiguration -MethodName "TriggerEvaluation" -Arguments $Arguments -ErrorAction Stop -OperationTimeoutSec 601
     }
-    Catch
-    {
+    Catch {
         Write-UILog -Severity Error -Message "Problem trigerring evaluation: $_" -UI $UI
-        $UI.Window.Dispatcher.Invoke({
-            $UI.Progress.IsIndeterminate = $false
-            $UI.expander.IsExpanded = $true
-        })
+        $UI.Window.Dispatcher.Invoke( {
+                $UI.Progress.IsIndeterminate = $false
+                $UI.expander.IsExpanded = $true
+            })
     }
 
     # Wait until the status of the baseline is Idle (0), Failure (4) or Reporting (5), or timeout of 600 seconds reached
     $Stopwatch = New-Object System.Diagnostics.Stopwatch
     $Stopwatch.Start()
     Do {
-       # Wait a couple of seconds for the status to update in WMI
-       Start-Sleep -Seconds 2
+        # Wait a couple of seconds for the status to update in WMI
+        Start-Sleep -Seconds 2
     }
-    Until ((Get-CimInstance -ComputerName $ComputerName -Namespace root\ccm\dcm -ClassName SMS_DesiredConfiguration -ErrorAction Stop | Where {$_.DisplayName -eq $DisplayName}).Status -in (0,4,5) -or $Stopwatch.Elapsed.TotalSeconds -gt 600)
+    Until ((Get-CimInstance -ComputerName $ComputerName -Namespace root\ccm\dcm -ClassName SMS_DesiredConfiguration -ErrorAction Stop | Where-Object { $_.DisplayName -eq $DisplayName }).Status -in (0, 4, 5) -or $Stopwatch.Elapsed.TotalSeconds -gt 600)
     $Stopwatch.Stop()
 
     # Wait a couple of seconds for the data to update in WMI
     Start-Sleep -Seconds 2
 
     # Clear the OCs before refreshing the configurations data again
-    If ($UI.DataContext[0])
-    {
-        $UI.DataContext.Clear()      
+    If ($UI.DataContext[0]) {
+        $UI.DataContext.Clear()
     }
 
-    If ($UI.Baselines[0])
-    {
-        $UI.Baselines.Clear()      
+    If ($UI.Baselines[0]) {
+        $UI.Baselines.Clear()
     }
 
     # Enable the Eval and Refresh buttons
-    $UI.Window.Dispatcher.Invoke({
-        $UI.BT_Eval.IsEnabled = $false
-        $UI.BT_Refresh.IsEnabled = $false
-    })
-    
+    $UI.Window.Dispatcher.Invoke( {
+            $UI.BT_Eval.IsEnabled = $false
+            $UI.BT_Refresh.IsEnabled = $false
+        })
+
     # Refresh the configurations data in the UI
     Get-Configurations -UI $UI -ComputerName $ComputerName
 
@@ -393,11 +357,10 @@ Function script:Evaluate-Baseline {
 
 # Function to check if a new version has been released
 Function Check-CurrentVersion {
-    Param($UI,$ThisVersion)
+    Param($UI, $ThisVersion)
 
     # Download XML from internet
-    Try
-    {
+    Try {
         # Use the raw.gihubusercontent.com/... URL
         $URL = "https://raw.githubusercontent.com/SMSAgentSoftware/ConfigMgr-Remote-Compliance/master/Versions/Remote_Compliance_Current.xml"
         $WebClient = New-Object System.Net.WebClient
@@ -410,8 +373,7 @@ Function Check-CurrentVersion {
         [void]$XMLDocument.Load($XMLReader)
         $Stream.Dispose()
     }
-    Catch
-    {
+    Catch {
         Return
     }
 
@@ -425,32 +387,30 @@ Function Check-CurrentVersion {
     [void]$Table.Columns.Add('Changes')
 
     # Add a row for each version
-    $UI.VersionHistory.Remote_Compliance.Versions.Version | sort Value -Descending | foreach {
-    
+    $UI.VersionHistory.Remote_Compliance.Versions.Version | Sort-Object Value -Descending | ForEach-Object {
+
         # The changes are put into an array, then converted to a string with each change on a new line for correct display
         [array]$Changes = $_.Changes.Change
         $ofs = "`r`n"
         $Table.Rows.Add($_.Value, $_.ReleaseDate, [string]$Changes)
-    
+
     }
 
     # Set the source of the datagrid
     $UI.VersionHistory.Add($Table)
 
     # Get Current version number
-    [double]$CurrentVersion = $XMLDocument.Remote_Compliance.Versions.Version.Value | Sort -Descending | Select -First 1
+    [double]$CurrentVersion = $XMLDocument.Remote_Compliance.Versions.Version.Value | Sort-Object -Descending | Select-Object -First 1
 
     # Enable the "Update" menut item to notify user
-    If ($CurrentVersion -gt $ThisVersion)
-    {
-        $UI.Window.Dispatcher.Invoke({
-            $UI.Update.Visibility = [System.Windows.Visibility]::Visible
-        })
+    If ($CurrentVersion -gt $ThisVersion) {
+        $UI.Window.Dispatcher.Invoke( {
+                $UI.Update.Visibility = [System.Windows.Visibility]::Visible
+            })
     }
 
     # Cleanup temp file
-    If (Test-Path -Path "$env:USERPROFILE\AppData\Local\Temp\Remote_Compliance_Current.xml")
-    {
+    If (Test-Path -Path "$env:USERPROFILE\AppData\Local\Temp\Remote_Compliance_Current.xml") {
         Remove-Item -Path "$env:USERPROFILE\AppData\Local\Temp\Remote_Compliance_Current.xml" -Force -Confirm:$false
     }
 
@@ -458,52 +418,51 @@ Function Check-CurrentVersion {
 
 # Popup message function
 function New-PopupMessage {
-# Return values for reference (https://msdn.microsoft.com/en-us/library/x83z1d9f(v=vs.84).aspx)
+    # Return values for reference (https://msdn.microsoft.com/en-us/library/x83z1d9f(v=vs.84).aspx)
 
-# Decimal value    Description  
-# -----------------------------
-# -1               The user did not click a button before nSecondsToWait seconds elapsed.
-# 1                OK button
-# 2                Cancel button
-# 3                Abort button
-# 4                Retry button
-# 5                Ignore button
-# 6                Yes button
-# 7                No button
-# 10               Try Again button
-# 11               Continue button
+    # Decimal value    Description
+    # -----------------------------
+    # -1               The user did not click a button before nSecondsToWait seconds elapsed.
+    # 1                OK button
+    # 2                Cancel button
+    # 3                Abort button
+    # 4                Retry button
+    # 5                Ignore button
+    # 6                Yes button
+    # 7                No button
+    # 10               Try Again button
+    # 11               Continue button
 
-# Define Parameters
-[CmdletBinding()]
+    # Define Parameters
+    [CmdletBinding()]
     [OutputType([int])]
     Param
     (
         # The popup message
-        [Parameter(Mandatory=$true,Position=0)]
+        [Parameter(Mandatory = $true, Position = 0)]
         [string]$Message,
 
         # The number of seconds to wait before closing the popup.  Default is 0, which leaves the popup open until a button is clicked.
-        [Parameter(Mandatory=$false,Position=1)]
+        [Parameter(Mandatory = $false, Position = 1)]
         [int]$SecondsToWait = 0,
 
         # The window title
-        [Parameter(Mandatory=$true,Position=2)]
+        [Parameter(Mandatory = $true, Position = 2)]
         [string]$Title,
 
         # The buttons to add
-        [Parameter(Mandatory=$true,Position=3)]
-        [ValidateSet('Ok','Ok-Cancel','Abort-Retry-Ignore','Yes-No-Cancel','Yes-No','Retry-Cancel','Cancel-TryAgain-Continue')]
+        [Parameter(Mandatory = $true, Position = 3)]
+        [ValidateSet('Ok', 'Ok-Cancel', 'Abort-Retry-Ignore', 'Yes-No-Cancel', 'Yes-No', 'Retry-Cancel', 'Cancel-TryAgain-Continue')]
         [array]$ButtonType,
 
         # The icon type
-        [Parameter(Mandatory=$true,Position=4)]
-        [ValidateSet('Stop','Question','Exclamation','Information')]
+        [Parameter(Mandatory = $true, Position = 4)]
+        [ValidateSet('Stop', 'Question', 'Exclamation', 'Information')]
         $IconType
     )
 
-# Convert button types
-switch($ButtonType)
-    {
+    # Convert button types
+    switch ($ButtonType) {
         "Ok" { $Button = 0 }
         "Ok-Cancel" { $Button = 1 }
         "Abort-Retry-Ignore" { $Button = 2 }
@@ -513,15 +472,14 @@ switch($ButtonType)
         "Cancel-TryAgain-Continue" { $Button = 6 }
     }
 
-# Convert Icon types
-Switch($IconType)
-    {
+    # Convert Icon types
+    Switch ($IconType) {
         "Stop" { $Icon = 16 }
         "Question" { $Icon = 32 }
         "Exclamation" { $Icon = 48 }
         "Information" { $Icon = 64 }
     }
 
-# Create the popup
-(New-Object -ComObject Wscript.Shell).popup($Message,$SecondsToWait,$Title,$Button + $Icon)
+    # Create the popup
+    (New-Object -ComObject Wscript.Shell).popup($Message, $SecondsToWait, $Title, $Button + $Icon)
 }


### PR DESCRIPTION
After converting the main script to *.exe the references used are no longer working in some OS Versions.
An easier way is to use the program reference itself so the $Source variable could be created.